### PR TITLE
Get today's permits instead of yesterday's

### DIFF
--- a/permits/permits.py
+++ b/permits/permits.py
@@ -136,9 +136,9 @@ def store_permits_for_date(date, in_lambda=False):
 
 
 def lambda_handler(event, context):
-    today = arrow.now().replace(days=-1)
+    today = arrow.now('America/Chicago')
     store_permits_for_date(today, in_lambda=True)
 
 if __name__ == '__main__':
-    today = arrow.now().replace(days=-1)
+    today = arrow.now('America/Chicago')
     store_permits_for_date(today, in_lambda=False)


### PR DESCRIPTION
I'd like to see how often the permits change in a day.

Gonna update the frequency in the AWS console manually to every 6 hours.
